### PR TITLE
Improve snapshot error messages with SNAPSHOT_UPDATE hint

### DIFF
--- a/lib/ink_snap.ex
+++ b/lib/ink_snap.ex
@@ -39,7 +39,13 @@ defmodule InkSnap do
         compare_snapshot!(snapshot_file, value)
 
       true ->
-        raise RuntimeError, "No snapshot for test: \"#{function_name}\"."
+        raise RuntimeError, """
+        No snapshot found for test: "#{function_name}".
+
+        Run the following to create it:
+
+            SNAPSHOT_UPDATE=true mix test
+        """
     end
   end
 
@@ -205,7 +211,13 @@ defmodule InkSnap do
       raise ExUnit.AssertionError,
         left: value,
         right: snapshot,
-        message: "Value does not match snapshot: #{file}",
+        message: """
+        Value does not match snapshot: #{file}
+
+        If this change is intentional, run the following to update it:
+
+            SNAPSHOT_UPDATE=true mix test
+        """,
         expr: "value == snapshot"
     end
   end

--- a/test/ink_snap_test.exs
+++ b/test/ink_snap_test.exs
@@ -45,13 +45,15 @@ defmodule InkSnapTest do
     end
 
     test "will raise an error if test doesn't have a snapshot", ctx do
-      message = "No snapshot for test: \"#{ctx.test}\"."
-
       refute System.get_env("SNAPSHOT_UPDATE", "false") == "true"
 
-      assert_raise RuntimeError, message, fn ->
-        handle_snapshot!("correct value", __ENV__)
-      end
+      error =
+        assert_raise RuntimeError, fn ->
+          handle_snapshot!("correct value", __ENV__)
+        end
+
+      assert error.message =~ "No snapshot found for test: \"#{ctx.test}\""
+      assert error.message =~ "SNAPSHOT_UPDATE=true mix test"
     end
   end
 end


### PR DESCRIPTION
## Summary

- When a snapshot file is missing, the error now explains how to create it with `SNAPSHOT_UPDATE=true mix test`
- When a snapshot value doesn't match, the error now explains how to update it with `SNAPSHOT_UPDATE=true mix test`, with a note that it should only be done if the change is intentional
- Both errors use multiline triple-quoted strings for readability
- Updated the test asserting the missing-snapshot error to check for key substrings rather than an exact message match

## Test Plan
- [ ] `mix test` passes (4/4)