### PR TITLE
Mix command to check for (and cleanup) unused snapshots

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.2
+erlang 27.3.4
 elixir 1.18.0-otp-27

--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ mix ink_snap.check
 
 It lists any snapshot file on disk that no test would produce and exits with a
 non-zero status when orphans are found, making it suitable as a CI gate. To delete
-the orphaned files (and prune any snapshot directories left empty), pass `--clean`:
+the orphaned files (and prune any snapshot directories left empty), pass `--delete`:
 
 ```bash
-mix ink_snap.check --clean
+mix ink_snap.check --delete
 ```
 
 The task compiles the project's test files to ask ExUnit for every registered

--- a/README.md
+++ b/README.md
@@ -99,6 +99,28 @@ way as a normal test:
 mix test test/sample_test.exs:12
 ```
 
+### Detecting Unused Snapshots
+
+Renaming or removing a snapshot test (and regenerating with `SNAPSHOT_UPDATE=true`)
+leaves the old snapshot file behind. Use the `ink_snap.check` task to detect these
+stale/orphaned snapshots:
+
+```bash
+mix ink_snap.check
+```
+
+It lists any snapshot file on disk that no test would produce and exits with a
+non-zero status when orphans are found, making it suitable as a CI gate. To delete
+the orphaned files (and prune any snapshot directories left empty), pass `--clean`:
+
+```bash
+mix ink_snap.check --clean
+```
+
+The task compiles the project's test files to ask ExUnit for every registered
+test, but it does **not** run any tests. It always runs in the `test` environment
+(re-invoking itself if necessary), since that is where snapshots live.
+
 ### Configuration
 
 `InkSnap` has a few few configuration options that can be set in the

--- a/lib/ink_snap.ex
+++ b/lib/ink_snap.ex
@@ -99,6 +99,17 @@ defmodule InkSnap do
     end
   end
 
+  @doc false
+  @spec snapshot_file_for(binary(), atom()) :: binary()
+  def snapshot_file_for(file, function), do: snapshot_file!(file, function)
+
+  @doc false
+  @spec snapshot_dirs() :: [binary()]
+  def snapshot_dirs do
+    dir = snapshot_directory()
+    Enum.map(test_paths(), &Path.join(&1, dir))
+  end
+
   ################################
   # Private API
   ################################

--- a/lib/mix/tasks/ink_snap.check.ex
+++ b/lib/mix/tasks/ink_snap.check.ex
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.InkSnap.Check do
   # Compute the set of snapshot paths that live tests would produce.
   defp expected_snapshots do
     test_files()
-    |> Enum.flat_map(&Code.require_file/1)
+    |> Enum.flat_map(fn file -> Code.require_file(file) || Code.compile_file(file) end)
     |> Enum.map(fn {module, _binary} -> module end)
     |> Enum.filter(&function_exported?(&1, :__ex_unit__, 0))
     |> Enum.flat_map(fn module -> module.__ex_unit__().tests end)

--- a/lib/mix/tasks/ink_snap.check.ex
+++ b/lib/mix/tasks/ink_snap.check.ex
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.InkSnap.Check do
   Prints each orphaned snapshot and exits with a non-zero status when any are
   found (suitable for CI).
 
-      mix ink_snap.check --clean
+      mix ink_snap.check --delete
 
   Deletes orphaned snapshots, prunes any snapshot directories left empty, and
   exits successfully.
@@ -50,18 +50,14 @@ defmodule Mix.Tasks.InkSnap.Check do
   end
 
   defp check(args) do
-    {opts, _, _} = OptionParser.parse(args, strict: [clean: :boolean])
-    clean? = Keyword.get(opts, :clean, false)
+    {opts, _, _} = OptionParser.parse(args, strict: [delete: :boolean])
+    delete? = Keyword.get(opts, :delete, false)
 
     Mix.Task.run("compile")
     Application.ensure_all_started(:ink_snap)
     # Start ExUnit so compiling test modules can register their tests, but never
-    # let it run them (this is a static dry run, not a test execution). Starting
-    # with autorun disabled first makes any ExUnit.start/0 in test_helper.exs a
-    # no-op for autorun, so the helper can still set up compile-time deps (Mox,
-    # etc.) that case templates reference.
+    # let them run (this is a static dry run, not a test execution).
     ExUnit.start(autorun: false)
-    load_test_helper()
 
     expected = expected_snapshots()
     existing = existing_snapshots()
@@ -71,7 +67,7 @@ defmodule Mix.Tasks.InkSnap.Check do
       orphans == [] ->
         Mix.shell().info("No unused snapshots found.")
 
-      clean? ->
+      delete? ->
         Enum.each(orphans, &File.rm!/1)
         prune_empty_dirs()
 
@@ -86,7 +82,7 @@ defmodule Mix.Tasks.InkSnap.Check do
 
         Remove them by running:
 
-            mix ink_snap.check --clean
+            mix ink_snap.check --delete
         """)
 
         exit({:shutdown, 1})
@@ -122,17 +118,6 @@ defmodule Mix.Tasks.InkSnap.Check do
 
   defp default_test_paths do
     if File.dir?("test"), do: ["test"], else: []
-  end
-
-  # Load the project's test helper so case templates can reference compile-time
-  # setup (Mox mocks, config, etc.). autorun was already disabled above, so the
-  # helper's own ExUnit.start/0 will not schedule a test run.
-  defp load_test_helper do
-    helper = Path.expand("test/test_helper.exs")
-
-    if File.exists?(helper) do
-      Code.require_file(helper)
-    end
   end
 
   # Remove snapshot subdirectories that became empty after deletion, bottom-up.

--- a/lib/mix/tasks/ink_snap.check.ex
+++ b/lib/mix/tasks/ink_snap.check.ex
@@ -1,0 +1,147 @@
+defmodule Mix.Tasks.InkSnap.Check do
+  @shortdoc "Detects unused (stale) snapshot files"
+
+  @moduledoc """
+  Detects stale/orphaned snapshot files left behind when a test is renamed or
+  removed after its snapshot was created.
+
+  It works by compiling the project's test files (a dry run: modules are
+  compiled but tests are **not** executed), asking ExUnit for every registered
+  test, and computing the snapshot path each test would use. Any `.snap` file on
+  disk that no test claims is reported as orphaned.
+
+  ## Usage
+
+      mix ink_snap.check
+
+  Prints each orphaned snapshot and exits with a non-zero status when any are
+  found (suitable for CI).
+
+      mix ink_snap.check --clean
+
+  Deletes orphaned snapshots, prunes any snapshot directories left empty, and
+  exits successfully.
+  """
+
+  use Mix.Task
+
+  @impl Mix.Task
+  def run(args) do
+    # Snapshots only exist under the test environment (that is where test files
+    # and their support modules compile). Mix locks the environment before a task
+    # loads and a third-party task cannot set it, so when invoked in any other
+    # env we re-exec ourselves as a subprocess with MIX_ENV=test.
+    if Mix.env() == :test do
+      check(args)
+    else
+      exit({:shutdown, rerun_in_test_env(args)})
+    end
+  end
+
+  defp rerun_in_test_env(args) do
+    {_out, status} =
+      System.cmd("mix", ["ink_snap.check" | args],
+        env: [{"MIX_ENV", "test"}],
+        into: IO.stream(:stdio, :line),
+        stderr_to_stdout: true
+      )
+
+    status
+  end
+
+  defp check(args) do
+    {opts, _, _} = OptionParser.parse(args, strict: [clean: :boolean])
+    clean? = Keyword.get(opts, :clean, false)
+
+    Mix.Task.run("compile")
+    Application.ensure_all_started(:ink_snap)
+    # Start ExUnit so compiling test modules can register their tests, but never
+    # let it run them (this is a static dry run, not a test execution). Starting
+    # with autorun disabled first makes any ExUnit.start/0 in test_helper.exs a
+    # no-op for autorun, so the helper can still set up compile-time deps (Mox,
+    # etc.) that case templates reference.
+    ExUnit.start(autorun: false)
+    load_test_helper()
+
+    expected = expected_snapshots()
+    existing = existing_snapshots()
+    orphans = Enum.sort(existing -- expected)
+
+    cond do
+      orphans == [] ->
+        Mix.shell().info("No unused snapshots found.")
+
+      clean? ->
+        Enum.each(orphans, &File.rm!/1)
+        prune_empty_dirs()
+
+        Mix.shell().info("Removed #{length(orphans)} unused snapshot(s):")
+        Enum.each(orphans, &Mix.shell().info("  #{relative(&1)}"))
+
+      true ->
+        Mix.shell().error("Found #{length(orphans)} unused snapshot(s):")
+        Enum.each(orphans, &Mix.shell().error("  #{relative(&1)}"))
+
+        Mix.shell().error("""
+
+        Remove them by running:
+
+            mix ink_snap.check --clean
+        """)
+
+        exit({:shutdown, 1})
+    end
+  end
+
+  # Compute the set of snapshot paths that live tests would produce.
+  defp expected_snapshots do
+    test_files()
+    |> Enum.flat_map(&Code.require_file/1)
+    |> Enum.map(fn {module, _binary} -> module end)
+    |> Enum.filter(&function_exported?(&1, :__ex_unit__, 0))
+    |> Enum.flat_map(fn module -> module.__ex_unit__().tests end)
+    |> Enum.map(fn %ExUnit.Test{name: name, tags: %{file: file}} ->
+      InkSnap.snapshot_file_for(file, name)
+    end)
+    |> Enum.uniq()
+  end
+
+  defp existing_snapshots do
+    InkSnap.snapshot_dirs()
+    |> Enum.flat_map(fn dir -> Path.wildcard(Path.join(dir, "**/*.snap")) end)
+    |> Enum.uniq()
+  end
+
+  defp test_files do
+    Mix.Project.config()
+    |> Keyword.get(:test_paths, default_test_paths())
+    |> Enum.flat_map(fn path -> Path.wildcard(Path.join(path, "**/*_test.exs")) end)
+    |> Enum.map(&Path.expand/1)
+    |> Enum.uniq()
+  end
+
+  defp default_test_paths do
+    if File.dir?("test"), do: ["test"], else: []
+  end
+
+  # Load the project's test helper so case templates can reference compile-time
+  # setup (Mox mocks, config, etc.). autorun was already disabled above, so the
+  # helper's own ExUnit.start/0 will not schedule a test run.
+  defp load_test_helper do
+    helper = Path.expand("test/test_helper.exs")
+
+    if File.exists?(helper) do
+      Code.require_file(helper)
+    end
+  end
+
+  # Remove snapshot subdirectories that became empty after deletion, bottom-up.
+  defp prune_empty_dirs do
+    for root <- InkSnap.snapshot_dirs(),
+        dir <- Enum.sort([root | Path.wildcard(Path.join(root, "**/"))], :desc) do
+      File.rmdir(dir)
+    end
+  end
+
+  defp relative(path), do: Path.relative_to_cwd(path)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule InkSnap.MixProject do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.1.1"
 
   ################################
   # Public API

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,7 @@ defmodule InkSnap.MixProject do
         "format --check-formatted",
         "credo --strict",
         "test --cover --export-coverage default",
+        "ink_snap.check",
         "dialyzer --format github"
       ]
     ]

--- a/test/mix/tasks/ink_snap.check_test.exs
+++ b/test/mix/tasks/ink_snap.check_test.exs
@@ -1,0 +1,63 @@
+defmodule Mix.Tasks.InkSnap.CheckTest do
+  use ExUnit.Case, async: false
+
+  @orphan "test/_snapshots/ink_snap_test/test_orphan_snapshot_from_test.snap"
+
+  setup do
+    on_exit(fn -> File.rm(@orphan) end)
+    :ok
+  end
+
+  describe "mix ink_snap.check" do
+    test "passes and exits 0 when there are no unused snapshots" do
+      {out, status} = run([])
+
+      assert status == 0
+      assert out =~ "No unused snapshots found."
+    end
+
+    test "reports orphans and exits 1" do
+      File.write!(@orphan, "%{}\n")
+
+      {out, status} = run([])
+
+      assert status == 1
+      assert out =~ "Found 1 unused snapshot(s)"
+      assert out =~ "test_orphan_snapshot_from_test.snap"
+      assert File.exists?(@orphan), "should not delete without --clean"
+    end
+
+    test "--clean deletes orphans and exits 0" do
+      File.write!(@orphan, "%{}\n")
+
+      {out, status} = run(["--clean"])
+
+      assert status == 0
+      assert out =~ "Removed 1 unused snapshot(s)"
+      refute File.exists?(@orphan)
+    end
+
+    test "--clean prunes directories left empty" do
+      dir = "test/_snapshots/nonexistent_test"
+      snap = Path.join(dir, "test_gone.snap")
+      File.mkdir_p!(dir)
+      File.write!(snap, "%{}\n")
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      {_out, status} = run(["--clean"])
+
+      assert status == 0
+      refute File.exists?(snap)
+      refute File.dir?(dir), "empty snapshot dir should be pruned"
+    end
+  end
+
+  # Run the task in an isolated subprocess (test env, so no re-exec) to avoid
+  # recursively compiling/starting ExUnit inside the running suite.
+  defp run(args) do
+    System.cmd("mix", ["ink_snap.check" | args],
+      env: [{"MIX_ENV", "test"}],
+      stderr_to_stdout: true
+    )
+  end
+end

--- a/test/mix/tasks/ink_snap.check_test.exs
+++ b/test/mix/tasks/ink_snap.check_test.exs
@@ -24,27 +24,27 @@ defmodule Mix.Tasks.InkSnap.CheckTest do
       assert status == 1
       assert out =~ "Found 1 unused snapshot(s)"
       assert out =~ "test_orphan_snapshot_from_test.snap"
-      assert File.exists?(@orphan), "should not delete without --clean"
+      assert File.exists?(@orphan), "should not delete without --delete"
     end
 
-    test "--clean deletes orphans and exits 0" do
+    test "--delete deletes orphans and exits 0" do
       File.write!(@orphan, "%{}\n")
 
-      {out, status} = run(["--clean"])
+      {out, status} = run(["--delete"])
 
       assert status == 0
       assert out =~ "Removed 1 unused snapshot(s)"
       refute File.exists?(@orphan)
     end
 
-    test "--clean prunes directories left empty" do
+    test "--delete prunes directories left empty" do
       dir = "test/_snapshots/nonexistent_test"
       snap = Path.join(dir, "test_gone.snap")
       File.mkdir_p!(dir)
       File.write!(snap, "%{}\n")
       on_exit(fn -> File.rm_rf(dir) end)
 
-      {_out, status} = run(["--clean"])
+      {_out, status} = run(["--delete"])
 
       assert status == 0
       refute File.exists?(snap)


### PR DESCRIPTION
## Purpose

* `mix ink_snap.check`
* `mix ink_snap.check --delete`


## Testing

`mix ink_snap.check`

```
Found 4 unused snapshot(s):
  test/_snapshots/inkio_rpc/servers/namespace_server_test/test_collection_create_2_will_create_a_collection.snap
  test/_snapshots/inkio_rpc/servers/namespace_server_test/test_collection_update_2_will_update_a_collection.snap
  test/_snapshots/inkio_rpc/servers/namespace_server_test/test_subspace_create_2_will_create_a_subspace.snap
  test/_snapshots/inkio_rpc/servers/namespace_server_test/test_subspace_update_2_will_update_a_subspace.snap

Remove them by running:

    mix ink_snap.check --delete
```

`mix ink_snap.check --delete`

```
Removed 4 unused snapshot(s):
  test/_snapshots/inkio_rpc/servers/namespace_server_test/test_collection_create_2_will_create_a_collection.snap
  test/_snapshots/inkio_rpc/servers/namespace_server_test/test_collection_update_2_will_update_a_collection.snap
  test/_snapshots/inkio_rpc/servers/namespace_server_test/test_subspace_create_2_will_create_a_subspace.snap
  test/_snapshots/inkio_rpc/servers/namespace_server_test/test_subspace_update_2_will_update_a_subspace.snap
```

* Return code `1` means unused snapshots were found
* Takes ~10 seconds on InkIO, ~11s in Helios

## AI Plan

<details>
<summary>Click to expand</summary>

# Plan: Detect unused snapshot files (`mix ink_snap.check`)

## Goal

Add a shippable mix task that detects stale/orphaned `.snap` files (left behind
when a test is renamed and `SNAPSHOT_UPDATE=true` regenerates snapshots under
the new name). Runnable in CI to fail on stale snapshots. Optional cleanup.

## Why this approach (static compile-time introspection, no test execution)

Evidence gathered:

- `test_grpc` (ink-io) and `test_snapshot` (ink-snap) are **wrapper macros**
  that both expand to a plain ExUnit `test` calling `InkSnap.handle_snapshot!`
  (see `deps/movableink/lib/movableink_grpc/snap_helpers.ex:78-85`). A naive
  "grep for `test_snapshot` calls" AST walk finds **zero** snapshot tests in
  ink-io. Wrapper macros are unknowable without expansion.
- The snapshot filename derives **only** from the composed ExUnit name
  (`"test #{describe} #{name}"`, `ex_unit/case.ex:701/705`) fed through
  `InkSnap`'s `snapshot_file_basename/1`. The wrapper macro name is irrelevant.
- Compiling a test file (`Code.require_file`) **expands all macros** and makes
  ExUnit record every final test as `%ExUnit.Test{}` in the module, readable via
  `module.__ex_unit__().tests` (`ex_unit/case.ex:629-637, 727-728`). This is a
  **dry run**: modules compile, tests do NOT execute.
- Each `%ExUnit.Test{}` carries `.name` (the atom = runtime `env.function`,
  already truncated by `build_test_name` if >255 bytes, `case.ex:922`) and
  `.tags.file` (source file). Both are exactly what `InkSnap.snapshot_file!/2`
  needs. Using `.name` (not `.description`) matches runtime filenames byte-for-byte.

Result: expected `.snap` set is computed correct-by-construction for ANY wrapper
macro, reusing InkSnap's own path logic. No suite run, no name-composition
reimplementation, no AST fragility.

## Changes

### 1. `lib/ink_snap.ex` — expose minimal internals (small refactor)

The task needs InkSnap's path + naming logic. Rather than duplicate, extract a
thin public (`@doc false`) helper and reuse existing private fns.

- Add `@doc false def snapshot_file_for(file, function_name)` that wraps the
  existing private `snapshot_file!/2`. (`snapshot_file!` already does everything:
  resolves test paths via cached config, builds
  `<test_path>/<snap_dir>/<sub_path>/<basename>`.) One-line delegation.
- Add `@doc false def snapshot_dirs()` returning, per resolved test path, the
  snapshot root dir `Path.join(test_path, snapshot_directory)` — the set of
  directories to scan for existing `.snap` files. Reuses `test_paths/0` +
  `snapshot_directory/0` (already private; expose via this wrapper only).
- No behavior change to existing runtime path. `snapshot_file!/2` already calls
  `Mix.Project.get!()` / `Mix.Project.config()`, which are available in a mix
  task context.

`ponytail:` reuse existing private fns, add only thin `@doc false` wrappers — no
new path logic.

### 2. `lib/mix/tasks/ink_snap.check.ex` — new mix task (ships in package)

`Mix.Task` named `ink_snap.check`. Algorithm:

1. `Mix.Task.run("compile")` then `Application.ensure_all_started(:ink_snap)`.
2. `ExUnit.start(autorun: false)` — required so `__after_compile__` registration
   (`case.ex:650-661`) doesn't raise; `autorun: false` prevents any run.
3. Load `test/test_helper.exs` if present (case templates / support live there),
   guarded by `File.exists?`. Rationale: test files `use SomeCase` from support.
4. Discover test files: for each dir from `InkSnap.snapshot_dirs()`'s parent test
   paths, glob `**/*_test.exs`. (Use `Mix.Project.config()[:test_paths]` /
   default `test`, mirroring InkSnap's own resolution.)
5. `Code.require_file/1` each test file (compile-only dry run). Collect all
   loaded ExUnit modules — track modules before/after, or scan required files'
   defined modules — and read `mod.__ex_unit__().tests`.
6. For each `%ExUnit.Test{name: name, tags: %{file: file}}`, compute expected
   path via `InkSnap.snapshot_file_for(file, name)`. Build `expected` MapSet.
7. Discover `existing` on disk: for each `InkSnap.snapshot_dirs()`, glob
   `**/*.snap` (only `*.snap`, nothing else ever touched).
8. `orphans = existing -- expected`.
9. Report:
   - No orphans → print OK, exit 0.
   - Orphans, no `--clean` → print each orphan path, print count, exit 1.
   - Orphans, `--clean` → delete each orphan (`File.rm!`), then prune now-empty
     snapshot subdirs (bottom-up `File.rmdir` ignoring non-empty), print what
     was removed, exit 0.

Flags: `--clean` (delete + prune empty dirs).

Safety: only files matching `*.snap` under resolved snapshot dirs are ever
considered or deleted. Non-`.snap` files ignored entirely.

Edge cases handled:
- Test excluded only by runtime tag filters still compiles → still counted (no
  false positive; this is the win over runtime tracking).
- Truncated long test names: `.name` atom already truncated identically to
  runtime → exact match.
- Multiple test paths / custom `:snapshot_directory` config → reuses InkSnap
  resolution, so consistent.
- `test/test_helper.exs` missing → skipped gracefully.

### 3. `mix.exs` — wire into CI

- Add `"ink_snap.check"` to the `ci` alias (`mix.exs:39-46`) so this repo's own
  CI gates on stale snapshots.
- `files:` list already includes `lib` (`mix.exs:83`), so
  `lib/mix/tasks/ink_snap.check.ex` ships in the hex package automatically —
  ink-io and other consumers get `mix ink_snap.check` for free. No change needed
  to `files:`.

### 4. `README.md` — document

Add a short "Detecting unused snapshots" section: `mix ink_snap.check`,
`mix ink_snap.check --clean`, and a CI usage note.

## Testing

- `test/mix/tasks/ink_snap.check_test.exs`: create a temp project fixture (or
  use this repo's own `test/_snapshots/`) with a known-orphan `.snap` file;
  assert the task detects it and exits non-zero; assert `--clean` removes it and
  prunes the empty dir; assert clean repo reports OK / exit 0.
- Manual: drop a bogus `test/_snapshots/ink_snap_test/test_bogus.snap`, run
  `mix ink_snap.check` → expect it flagged; `--clean` → expect it gone.

## Risks / open notes

- Compiling test files runs any **compile-time** (not test-time) side effects in
  those files. Standard ExUnit test files have none; acceptable and unavoidable
  for a dry run. Documented.
- Requires the project's test support (case templates) to be loadable — handled
  by compiling first + loading `test_helper.exs`.
- Collecting "which modules were defined by a required file": use
  `Code.require_file/1` return value (list of `{module, binary}`) to get exactly
  the modules per file — robust, no global module diffing needed.

</details>